### PR TITLE
V09 kernel brings back flexible coin stake transaction timestamp.

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -45,6 +45,7 @@ BITCOIN_TESTS =\
   test/DoS_tests.cpp \
   test/getarg_tests.cpp \
   test/hash_tests.cpp \
+  test/kernel_tests.cpp \
   test/key_tests.cpp \
   test/limitedmap_tests.cpp \
   test/dbwrapper_tests.cpp \

--- a/src/chain.h
+++ b/src/chain.h
@@ -27,7 +27,7 @@ static const int64_t MAX_FUTURE_BLOCK_TIME = 15 * 60;
  * Timestamp window used as a grace period by code that compares external
  * timestamps (such as timestamps passed to RPCs, or wallet key creation times)
  * to block timestamps. This should be set at least as high as
- * MAX_FUTURE_BLOCK_TIME.
+ * MAX_FUTURE_BLOCK_TIME_PREV9.
  */
 static const int64_t TIMESTAMP_WINDOW = MAX_FUTURE_BLOCK_TIME_PREV9;
 

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -597,10 +597,19 @@ bool CheckProofOfStake(CValidationState &state, CBlockIndex* pindexPrev, const C
 // Check whether the coinstake timestamp meets protocol
 bool CheckCoinStakeTimestamp(int64_t nTimeBlock, int64_t nTimeTx)
 {
-    if (IsProtocolV03(nTimeTx))  // v0.3 protocol
-        return (nTimeBlock == nTimeTx);
-    else // v0.2 protocol
-        return ((nTimeTx <= nTimeBlock) && (nTimeBlock <= nTimeTx + (IsProtocolV09(nTimeBlock) ? MAX_FUTURE_BLOCK_TIME : MAX_FUTURE_BLOCK_TIME_PREV9)));
+    if (nTimeTx > nTimeBlock) {
+        return false;
+    }
+
+    if (IsProtocolV09(nTimeTx)) {
+        return nTimeBlock <= nTimeTx + MAX_FUTURE_BLOCK_TIME;
+    }
+    else if (IsProtocolV03(nTimeTx)) {
+        return nTimeBlock == nTimeTx;
+    }
+    else { // Protocol v0.2
+        return nTimeBlock <= nTimeTx + MAX_FUTURE_BLOCK_TIME_PREV9;
+    }
 }
 
 // Get stake modifier checksum

--- a/src/test/kernel_tests.cpp
+++ b/src/test/kernel_tests.cpp
@@ -1,0 +1,187 @@
+// Copyright (c) 2020 Peercoin Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+
+#include <kernel.h>
+#include <test/test_bitcoin.h>
+
+
+BOOST_FIXTURE_TEST_SUITE(kernel_tests, BasicTestingSetup)
+
+// Cases to consider for each kernel protocol:
+
+// The first transaction time of the protocol
+//   * block at same time -> true
+//   * block at same time - 1 -> false
+//   * block at maximum time difference -> true
+//   * block at maximum time difference + 1 -> false
+
+// The last transaction time of the protocol
+//   * block at same time -> true
+//   * block at same time - 1 -> false
+//   * block at maximum time difference -> true
+//   * block at maximum time difference + 1 -> false
+
+BOOST_AUTO_TEST_CASE(check_coin_stake_timestamp_protocol_v02_test)
+{
+    // In the v0.2 kernel the timestamp of the coin stake transaction must be
+    // on or before (up to 2 hours) the block timestamp.
+
+    // first time of the protocol:
+    //     since the beginning of time :)
+    // last time of the protocol:
+    //     unsigned int nProtocolV03SwitchTime     = 1363800000 - 1;
+    // maximum time difference:
+    //     static const int64_t MAX_FUTURE_BLOCK_TIME_PREV9 = 2 * 60 * 60;
+
+    int64_t last_protocol_transaction_time = 1363800000 - 1;
+    int64_t maximum_future_block_time = 2 * 60 * 60; // 2 hours
+
+    BOOST_CHECK_EQUAL(
+        CheckCoinStakeTimestamp(
+            last_protocol_transaction_time,
+            last_protocol_transaction_time
+        ),
+        true
+    );
+
+    BOOST_CHECK_EQUAL(
+        CheckCoinStakeTimestamp(
+            last_protocol_transaction_time - 1,
+            last_protocol_transaction_time
+        ),
+        false
+    );
+
+    BOOST_CHECK_EQUAL(
+        CheckCoinStakeTimestamp(
+            last_protocol_transaction_time + maximum_future_block_time,
+            last_protocol_transaction_time
+        ),
+        true
+    );
+
+    BOOST_CHECK_EQUAL(
+        CheckCoinStakeTimestamp(
+            last_protocol_transaction_time + maximum_future_block_time + 1,
+            last_protocol_transaction_time
+        ),
+        false
+    );
+}
+
+BOOST_AUTO_TEST_CASE(check_coin_stake_timestamp_protocol_v03_test)
+{
+    // In the v0.3 kernel the timestamp of the block and the coin stake
+    // transaction must match.
+
+    // first time of the protocol:
+    //     unsigned int nProtocolV03SwitchTime     = 1363800000;
+    // last time of the protocol:
+    //     const unsigned int nProtocolV09SwitchTime     = 1590062400 - 1; // Thu 21 May 12:00:00 UTC 2020 - 1
+    // maximum future block time:
+    //     0 (transaction time must match block time)
+
+    int64_t first_protocol_transaction_time = 1363800000;
+    int64_t last_protocol_transaction_time = 1590062400 - 1;
+
+    BOOST_CHECK_EQUAL(
+        CheckCoinStakeTimestamp(
+            first_protocol_transaction_time,
+            first_protocol_transaction_time
+        ),
+        true
+    );
+
+    BOOST_CHECK_EQUAL(
+        CheckCoinStakeTimestamp(
+            first_protocol_transaction_time - 1,
+            first_protocol_transaction_time
+        ),
+        false
+    );
+
+    BOOST_CHECK_EQUAL(
+        CheckCoinStakeTimestamp(
+            first_protocol_transaction_time + 1,
+            first_protocol_transaction_time
+        ),
+        false
+    );
+
+    BOOST_CHECK_EQUAL(
+        CheckCoinStakeTimestamp(
+            last_protocol_transaction_time,
+            last_protocol_transaction_time
+        ),
+        true
+    );
+
+    BOOST_CHECK_EQUAL(
+        CheckCoinStakeTimestamp(
+            last_protocol_transaction_time - 1,
+            last_protocol_transaction_time
+        ),
+        false
+    );
+
+    BOOST_CHECK_EQUAL(
+        CheckCoinStakeTimestamp(
+            last_protocol_transaction_time + 1,
+            last_protocol_transaction_time
+        ),
+        false
+    );
+}
+
+BOOST_AUTO_TEST_CASE(check_coin_stake_timestamp_protocol_v09_test)
+{
+    // In the v0.9 kernel the timestamp of the coin stake transaction must be
+    // on or before (up to 15 minutes) the block timestamp.
+
+    // first time of the protocol:
+    //     const unsigned int nProtocolV09SwitchTime     = 1590062400; // Thu 21 May 12:00:00 UTC 2020
+    // last time of the protocol:
+    //     until the end of time :)
+    // maximum future block time:
+    //     static const int64_t MAX_FUTURE_BLOCK_TIME_PREV9 = 15 * 60;
+
+    int64_t first_protocol_transaction_time = 1590062400;
+    int64_t maximum_future_block_time = 15 * 60; // 15 minutes
+
+    BOOST_CHECK_EQUAL(
+        CheckCoinStakeTimestamp(
+            first_protocol_transaction_time,
+            first_protocol_transaction_time
+        ),
+        true
+    );
+
+    BOOST_CHECK_EQUAL(
+        CheckCoinStakeTimestamp(
+            first_protocol_transaction_time - 1,
+            first_protocol_transaction_time
+        ),
+        false
+    );
+
+    BOOST_CHECK_EQUAL(
+        CheckCoinStakeTimestamp(
+            first_protocol_transaction_time + maximum_future_block_time,
+            first_protocol_transaction_time
+        ),
+        true
+    );
+
+    BOOST_CHECK_EQUAL(
+        CheckCoinStakeTimestamp(
+            first_protocol_transaction_time + maximum_future_block_time + 1,
+            first_protocol_transaction_time
+        ),
+        false
+    );
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
I wrote some tests around `CheckCoinStakeTimestamp` because it looked like the code was trying to re-introduce a flexible coin-stake transaction in the v0.9 kernel protocol but was still enforcing v0.3 (strict match between transaction and block timestamp) even when v0.9 should be in effect.